### PR TITLE
 solve `centos_install()` failing to change root dir for non-root via dnf system call

### DIFF
--- a/R/centos.R
+++ b/R/centos.R
@@ -11,13 +11,13 @@ centos_install <- function(pkgs) {
 
 centos_install_nonroot <- function() {
   rpm_list <- list.files(pattern = ".rpm")
-  assert_centos_nonroot_extras()
+  check_centos_nonroot_reqs()
   for (rpm in rpm_list) {
     system("rpm2cpio", rpm, "| cpio", "--directory", user_dir(), "-id")
   }
 }
 
-assert_centos_nonroot_extras <- function() {
+check_centos_nonroot_reqs <- function() {
   reqs <- c("rpm2cpio", "cpio")
   reqs <- Sys.which(reqs)
   idx <- reqs == ""
@@ -25,7 +25,7 @@ assert_centos_nonroot_extras <- function() {
     stop("Non-root requires 'rpm2cpio' and 'cpio' tools to unpack and copy ",
       "RPM packages into home directory without admin (sudo) rights.",
       "Quit current R session. Then install missing in shell with \n",
-      p("`sudo dnf install", paste0(missing, "`")), "\n",
+      p("`sudo dnf install", paste0(missing, "`.")), "\n",
       "Restart R and run `rspm::enable()` again to proceed.",
       call. = FALSE
     )

--- a/R/centos.R
+++ b/R/centos.R
@@ -5,18 +5,28 @@ centos_install <- function(pkgs) {
   old <- setwd(temp)
   on.exit(setwd(old))
   system(centos_cmd(), p(pkgs))
-  system("rpm -i --nodeps --noscripts --notriggers --nosignature --excludedocs",
-         "-r", user_dir(), "*")
+  if (system("id -u") != 0) {
+    rpm_list <- list.files(pattern = ".rpm")
+    for (rpm in rpm_list) {
+      system("rpm2cpio", rpm, "| cpio", "--directory", user_dir(), "-id")
+    }
+  } else {
+    system(
+      "rpm -i --nodeps --noscripts --notriggers --nosignature --excludedocs",
+      "-r", user_dir(), "*"
+    )
+  }
 }
 
 centos_install_sysreqs <- function(libs) {
   cat("Downloading and installing sysreqs...\n")
-  centos_install(paste0("*/", libs, collapse=" "))
+  centos_install(paste0("*/", libs, collapse = " "))
 }
 
 centos_cmd <- function() {
   cmd <- "yumdownloader --resolve"
-  if (Sys.which("dnf") != "")
+  if (Sys.which("dnf") != "") {
     cmd <- "dnf download --resolve"
+  }
   cmd
 }

--- a/R/centos.R
+++ b/R/centos.R
@@ -5,7 +5,7 @@ centos_install <- function(pkgs) {
   old <- setwd(temp)
   on.exit(setwd(old))
   system(centos_cmd(), p(pkgs))
-  uid <- as.integer(base::system("id -u", intern = TRUE))
+  uid <- as.integer(system_("id -u"))
   if (uid != 0) {
     # non-root
     rpm_list <- list.files(pattern = ".rpm")

--- a/R/centos.R
+++ b/R/centos.R
@@ -6,7 +6,7 @@ centos_install <- function(pkgs) {
   on.exit(setwd(old))
   system(centos_cmd(), p(pkgs))
   uid <- as.integer(system_("id -u"))
-  if (uid != 0L) centos_install_nontroot() else centos_install_root()
+  if (uid != 0L) centos_install_nonroot() else centos_install_root()
 }
 
 centos_install_nonroot <- function() {

--- a/R/centos.R
+++ b/R/centos.R
@@ -26,7 +26,8 @@ check_centos_nonroot_reqs <- function() {
       "RPM packages into home directory without admin (sudo) rights.",
       "Quit current R session. Then install missing in shell with \n",
       p("`sudo dnf install", paste0(missing, "`.")), "\n",
-      "Restart R and run `rspm::enable()` again to proceed.",
+      "Restart R and run `rspm::enable()` again to proceed the installation
+      the desired R package via `install.packages()`.",
       call. = FALSE
     )
   }

--- a/R/centos.R
+++ b/R/centos.R
@@ -26,7 +26,7 @@ check_centos_nonroot_reqs <- function() {
       "RPM packages into home directory without admin (sudo) rights.",
       "Quit current R session. Then install missing in shell with \n",
       p("`sudo dnf install", paste0(missing, "`.")), "\n",
-      "Restart R and run `rspm::enable()` again to proceed the installation
+      "Restart R and run `rspm::enable()` again to proceed installing
       the desired R package via `install.packages()`.",
       call. = FALSE
     )

--- a/R/centos.R
+++ b/R/centos.R
@@ -7,6 +7,7 @@ centos_install <- function(pkgs) {
   system(centos_cmd(), p(pkgs))
   uid <- as.integer(base::system("id -u", intern = TRUE))
   if (uid != 0) {
+    # non-root
     rpm_list <- list.files(pattern = ".rpm")
     for (rpm in rpm_list) {
       system("rpm2cpio", rpm, "| cpio", "--directory", user_dir(), "-id")

--- a/R/centos.R
+++ b/R/centos.R
@@ -5,7 +5,8 @@ centos_install <- function(pkgs) {
   old <- setwd(temp)
   on.exit(setwd(old))
   system(centos_cmd(), p(pkgs))
-  if (system("id -u") != 0) {
+  uid <- as.integer(base::system("id -u", intern = TRUE))
+  if (uid != 0) {
     rpm_list <- list.files(pattern = ".rpm")
     for (rpm in rpm_list) {
       system("rpm2cpio", rpm, "| cpio", "--directory", user_dir(), "-id")


### PR DESCRIPTION
Dear @Enchufa2 ,

First of all thanks a lot for offering a solution for binary installs with convoluted system deps in CentOS/RHEL(-alike) distros, closing a considerable gap around RSPM/bspm/renv. Really like the design and the clarity of how interfaces are coded! So it it was straight-forward to dig in deeper.

In the current version in main, when invoking `rspm::enable()`, I got the error tracing back to the rpm install command via `system()`. 

```r
r$> rspm::enable()
Downloading and installing required utilities...
Not root, Subscription Management repositories not updated

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 10:10:36 ago on Sa 19 Nov 2022 11:59:47 CET.
patchelf-0.12-1.el8.x86_64.rpm              2.0 MB/s |  88 kB     00:00    
warning: Unable to get systemd shutdown inhibition lock: Permission denied
error: Unable to change root directory: Operation not permitted
Error: something went wrong, utilities not available
```

This is the current setup:

```
r$> remotes::install_github("Enchufa2/rspm", ref = "32abd91")
    library("rspm")
    sessioninfo::session_info()
Skipping install of 'rspm' from a github remote, the SHA1 (32abd913) has not changed since last install.
  Use `force = TRUE` to force installation
─ Session info ───────────────────────────────────────────────────────────
 setting  value
 version  R version 4.2.1 (2022-06-23)
 os       Rocky Linux 8.7 (Green Obsidian)
 system   x86_64, linux-gnu
 ui       X11
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       Europe/Zurich
 date     2022-11-19
 pandoc   NA

─ Packages ───────────────────────────────────────────────────────────────
 package     * version date (UTC) lib source
 cli           3.4.1   2022-09-23 [1] CRAN (R 4.2.1)
 curl          4.3.2   2021-06-23 [1] CRAN (R 4.2.1)
 remotes       2.4.2   2021-11-30 [1] CRAN (R 4.2.1)
 rspm        * 0.2.2   2022-11-19 [1] Github (Enchufa2/rspm@32abd91)
 sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.2.1)

 [1] /home/spectral-cockpit/R/x86_64-pc-linux-gnu-library/4.2
 [2] /opt/R/4.2.1/lib/R/library

──────────────────────────────────────────────────────────────────────────
```

There seems to be no permission issue as outlined as possible reason for the same underlying message in #9 .

```r
r$> rspm:::system("ls -la", rspm:::user_dir())
total 0
drwxr-xr-x. 3 spectral-cockpit spectral-cockpit 17 19. Nov 21:53 .
drwxr-xr-x. 3 spectral-cockpit spectral-cockpit 18 19. Nov 21:53 ..
drwxr-xr-x. 3 spectral-cockpit spectral-cockpit 17 19. Nov 21:53 var
```

It looks like the flag `--root` (`-r`) for `dnf` cmd is not working unless being root. At least for my rocky 8.7 miniserver. To be honest, I don't have enough knowledge of the inner mechanistics of .RPM and the dnf tool. Could be a bug ( https://bugzilla.redhat.com/show_bug.cgi?id=1963151 ) or actually just by design because some other root directories are touched (maybe it looks for rpmdb etc.). The `--prefix` trick did also not work, probably for similar reasons.

I found a workaround via extracting and copying the .RPM archive to the user directory of rspm, via `rpm2cpio` and stdin into `cpio`. Found this strategy on stackoverflow (e.g., https://superuser.com/questions/209808/how-can-i-install-an-rpm-without-being-root ) and here : https://scicomp.ethz.ch/wiki/Unpacking_RPM_packages . 